### PR TITLE
Complete Effect runtime migration for services and examples

### DIFF
--- a/__tests__/README.md
+++ b/__tests__/README.md
@@ -27,20 +27,16 @@ bun test:watch
 
 ### Restart Policy Tests
 
-The restart policy tests use a `MockService` class that can be configured to fail a set number of times before succeeding. This allows us to test different restart behaviors:
+The restart policy suite uses Effect-based mock services to validate different behaviours:
 
-1. **No restart policy**: Services should not be restarted when they fail
-2. **Max retries**: Services should be restarted up to the maximum number of retries when using the "on-failure" policy
-3. **Restart count reset**: The restart count should be reset after a successful start
+1. **`"no"` policy** – ensure services are not restarted after a crash
+2. **`"on-failure"` with `maxRetries`** – verify exponential back-off limits restart attempts
+3. **Restart counter reset** – confirm the counter resets after a successful run
+4. **Short-lived services** – immediate completions should not be treated as startup failures
+5. **`"always"` policy** – successful completions trigger an automatic restart
 
-To facilitate testing without timers, a `TestServiceManager` class is used to directly trigger service restarts.
+Each assertion uses `Effect.runPromise`, so the tests execute the same code paths as production consumers.
 
 ### Cron Job Tests
 
-The cron job tests verify that:
-
-1. Services can be added with cron configuration
-2. Cron jobs are properly managed when services are stopped
-3. Cron jobs are removed when services are removed
-
-These tests focus on the integration between the ServiceManager and the cron module, ensuring that cron jobs are properly created, started, and stopped.
+Cron tests focus on registration, removal and manual stopping of scheduled services. They use a lightweight Effect service that simply counts `start`/`stop` invocations.

--- a/__tests__/cron-job.test.ts
+++ b/__tests__/cron-job.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach } from "bun:test";
+import { Effect } from "effect";
 import { BaseService, ServiceManager } from "../index";
+import type { HealthCheckResult } from "../src/interface";
 
 // Silence the deprecation warnings during tests
 console.warn = () => {};
@@ -13,12 +15,14 @@ class CronTestService extends BaseService {
     super(name);
   }
 
-  async start(): Promise<void> {
+  protected onStart() {
     this.startCount++;
+    return Effect.void;
   }
 
-  async stop(): Promise<void> {
+  protected onStop() {
     this.stopCount++;
+    return Effect.void;
   }
 }
 
@@ -55,10 +59,12 @@ describe("ServiceManager - Cron Jobs", () => {
     });
 
     // Stop service
-    await manager.stopService("cron-test");
+    await Effect.runPromise(manager.stopService("cron-test"));
 
     // Check service status
-    const health = await manager.healthCheckService("cron-test");
+    const health: HealthCheckResult = await Effect.runPromise(
+      manager.healthCheckService("cron-test")
+    );
     expect(health.status).toBe("stopped");
   });
 

--- a/examples/services/logService.ts
+++ b/examples/services/logService.ts
@@ -1,3 +1,4 @@
+import { Effect } from "effect";
 import { expose } from "../../index";
 import type { HealthCheckResult, IService } from "../../src/interface";
 
@@ -7,35 +8,39 @@ class LoggingService implements IService {
   private logInterval: NodeJS.Timeout | null = null;
   private startTime = 0;
 
-  async start(): Promise<void> {
-    console.log("loggingService started");
-    this.isRunning = true;
-    this.startTime = Date.now();
+  start() {
+    return Effect.sync(() => {
+      console.log("loggingService started");
+      this.isRunning = true;
+      this.startTime = Date.now();
 
-    let count = 0;
-    this.logInterval = setInterval(() => {
-      console.log("loggingService log", count++);
-    }, 1000);
+      let count = 0;
+      this.logInterval = setInterval(() => {
+        console.log("loggingService log", count++);
+      }, 1000);
+    });
   }
 
-  async stop(): Promise<void> {
-    console.log("loggingService stopped");
-    this.isRunning = false;
+  stop() {
+    return Effect.sync(() => {
+      console.log("loggingService stopped");
+      this.isRunning = false;
 
-    if (this.logInterval) {
-      clearInterval(this.logInterval);
-      this.logInterval = null;
-    }
+      if (this.logInterval) {
+        clearInterval(this.logInterval);
+        this.logInterval = null;
+      }
+    });
   }
 
-  async healthCheck(): Promise<HealthCheckResult> {
-    return {
+  healthCheck() {
+    return Effect.succeed<HealthCheckResult>({
       status: this.isRunning ? "running" : "stopped",
       details: {
         uptime: this.isRunning ? (Date.now() - this.startTime) / 1000 : 0,
         logs: "healthy",
       },
-    };
+    });
   }
 }
 

--- a/examples/services/simpleWorker.ts
+++ b/examples/services/simpleWorker.ts
@@ -1,3 +1,4 @@
+import { Effect } from "effect";
 import { expose } from "../../index";
 import type { HealthCheckResult, IService } from "../../src/interface";
 
@@ -12,47 +13,51 @@ class CounterService implements IService {
   private maxCount = 10;
   private interval: NodeJS.Timeout | null = null;
 
-  async start(): Promise<void> {
-    console.log("CounterService started");
-    this.running = true;
-    this.count = 0;
+  start() {
+    return Effect.sync(() => {
+      console.log("CounterService started");
+      this.running = true;
+      this.count = 0;
 
-    // Run a counter task
-    this.interval = setInterval(() => {
-      this.count++;
-      console.log(`Count: ${this.count}`);
+      // Run a counter task
+      this.interval = setInterval(() => {
+        this.count++;
+        console.log(`Count: ${this.count}`);
 
-      // Stop when reached max count
-      if (this.count >= this.maxCount) {
-        this.running = false;
-        if (this.interval) {
-          clearInterval(this.interval);
-          this.interval = null;
+        // Stop when reached max count
+        if (this.count >= this.maxCount) {
+          this.running = false;
+          if (this.interval) {
+            clearInterval(this.interval);
+            this.interval = null;
+          }
+          console.log("CounterService completed task");
         }
-        console.log("CounterService completed task");
+      }, 1000);
+    });
+  }
+
+  stop() {
+    return Effect.sync(() => {
+      console.log("CounterService stopped");
+      this.running = false;
+
+      if (this.interval) {
+        clearInterval(this.interval);
+        this.interval = null;
       }
-    }, 1000);
+    });
   }
 
-  async stop(): Promise<void> {
-    console.log("CounterService stopped");
-    this.running = false;
-
-    if (this.interval) {
-      clearInterval(this.interval);
-      this.interval = null;
-    }
-  }
-
-  async healthCheck(): Promise<HealthCheckResult> {
-    return {
+  healthCheck() {
+    return Effect.succeed<HealthCheckResult>({
       status: this.running ? "running" : "stopped",
       details: {
         currentCount: this.count,
         maxCount: this.maxCount,
         progress: `${this.count}/${this.maxCount}`,
       },
-    };
+    });
   }
 }
 

--- a/examples/worker-restart-policy.ts
+++ b/examples/worker-restart-policy.ts
@@ -1,4 +1,6 @@
+import { Effect } from "effect";
 import { ServiceManager, createWorkerService } from "../index";
+import type { HealthCheckResult } from "../src/interface";
 
 // Set up a more robust error handling for Node.js
 process.on("unhandledRejection", (reason) => {
@@ -25,12 +27,14 @@ manager.addService(workerService, {
 try {
   // Start the service
   console.log("Starting worker service with max retries of 3...");
-  await manager.startService(workerService.name);
+  await Effect.runPromise(manager.startService(workerService.name));
 
   // Watch service status
   const statusInterval = setInterval(async () => {
     try {
-      const health = await manager.healthCheckService(workerService.name);
+      const health: HealthCheckResult = await Effect.runPromise(
+        manager.healthCheckService(workerService.name)
+      );
       console.log(
         `[${new Date().toISOString()}] Service status: ${health.status}, restart count: ${(manager as any).serviceMap.get(workerService.name)?.restartCount || 0}`
       );

--- a/examples/worker-with-data.ts
+++ b/examples/worker-with-data.ts
@@ -1,3 +1,4 @@
+import { Effect } from "effect";
 import { ServiceManager, createWorkerService } from "../index";
 
 // Create a worker service with custom data
@@ -29,11 +30,13 @@ manager.addService(workerService, {
 try {
   // Start the service
   console.log("Starting worker service with custom data...");
-  await manager.startService(workerService.name);
+  await Effect.runPromise(manager.startService(workerService.name));
 
   // Check health status after a while to see the custom data in health details
   setTimeout(async () => {
-    const health = await manager.healthCheckService(workerService.name);
+    const health = await Effect.runPromise(
+      manager.healthCheckService(workerService.name)
+    );
     console.log("Health check result:", health);
   }, 2000);
 

--- a/index.ts
+++ b/index.ts
@@ -10,23 +10,19 @@
  * import { BaseService, ServiceManager } from "j8s";
  *
  * class MyService extends BaseService {
- *   async start(): Promise<void> {
- *     console.log("Service started");
+ *   protected onStart() {
+ *     return Effect.sync(() => console.log("Service started"));
  *   }
  *
- *   async stop(): Promise<void> {
- *     console.log("Service stopped");
- *   }
- *
- *   async healthCheck(): Promise<HealthCheckResult> {
- *     return { status: "running" };
+ *   protected onStop() {
+ *     return Effect.sync(() => console.log("Service stopped"));
  *   }
  * }
  *
  * const manager = new ServiceManager();
  * const myService = new MyService("my-service");
  * manager.addService(myService, { restartPolicy: "always" });
- * await manager.startService(myService);
+ * await Effect.runPromise(manager.startService("my-service"));
  * ```
  *
  * @example
@@ -45,7 +41,7 @@
  *   restartPolicy: "on-failure",
  *   maxRetries: 3,
  * });
- * await manager.startService(workerService);
+ * await Effect.runPromise(manager.startService("worker-service"));
  * ```
  *
  * @example
@@ -54,15 +50,12 @@
  * import { BaseService, ServiceManager } from "j8s";
  *
  * class BackupService extends BaseService {
- *   async start(): Promise<void> {
- *     console.log("Running backup...");
- *     // Do backup logic here
+ *   protected onStart() {
+ *     return Effect.sync(() => console.log("Running backup..."));
  *   }
  *
- *   async stop(): Promise<void> {}
- *
- *   async healthCheck(): Promise<HealthCheckResult> {
- *     return { status: "running" };
+ *   protected onStop() {
+ *     return Effect.void;
  *   }
  * }
  *
@@ -88,23 +81,24 @@
  *   name = "worker-service";
  *   private running = false;
  *
- *   async start(): Promise<void> {
- *     console.log("Worker service started");
- *     this.running = true;
+ *   start() {
+ *     return Effect.sync(() => {
+ *       console.log("Worker service started");
+ *       this.running = true;
+ *     });
  *   }
  *
- *   async stop(): Promise<void> {
- *     console.log("Worker service stopped");
- *     this.running = false;
+ *   stop() {
+ *     return Effect.sync(() => {
+ *       console.log("Worker service stopped");
+ *       this.running = false;
+ *     });
  *   }
  *
- *   async healthCheck(): Promise<HealthCheckResult> {
- *     return {
+ *   healthCheck() {
+ *     return Effect.succeed({
  *       status: this.running ? "running" : "stopped",
- *       details: {
- *         // Custom health check details
- *       },
- *     };
+ *     });
  *   }
  * }
  *
@@ -135,6 +129,13 @@ export { BaseService } from "./src/BaseService";
  * Service manager for managing all services.
  */
 export { ServiceManager } from "./src/ServiceManager";
+export type { ServiceManagerOptions } from "./src/ServiceManager";
+
+/**
+ * Helper to build an IService from plain Effect functions.
+ */
+export { createService } from "./src/createService";
+export type { ServiceDefinition } from "./src/createService";
 
 /**
  * Worker service for running services in a worker thread.

--- a/src/BaseService.ts
+++ b/src/BaseService.ts
@@ -1,3 +1,4 @@
+import { Effect } from "effect";
 import type { HealthCheckResult, IService } from "./interface";
 
 /**
@@ -5,21 +6,31 @@ import type { HealthCheckResult, IService } from "./interface";
  * Status management is handled by the ServiceManager.
  */
 export abstract class BaseService implements IService {
-  public name: string;
+  public readonly name: string;
 
   constructor(name: string) {
     this.name = name;
   }
 
-  public abstract start(): Promise<void>;
-  public abstract stop(): Promise<void>;
+  protected abstract onStart(): Effect.Effect<void, unknown>;
+  protected abstract onStop(): Effect.Effect<void, unknown>;
 
-  public async healthCheck(): Promise<HealthCheckResult> {
-    // Return a minimal health check
-    // The ServiceManager will add the correct status
-    return {
-      status: "stopped", // This will be replaced by ServiceManager
+  protected onHealthCheck(): Effect.Effect<HealthCheckResult, unknown> {
+    return Effect.succeed({
+      status: "stopped",
       details: {},
-    };
+    });
+  }
+
+  public start(): Effect.Effect<void, unknown> {
+    return this.onStart();
+  }
+
+  public stop(): Effect.Effect<void, unknown> {
+    return this.onStop();
+  }
+
+  public healthCheck(): Effect.Effect<HealthCheckResult, unknown> {
+    return this.onHealthCheck();
   }
 }

--- a/src/WorkerService.ts
+++ b/src/WorkerService.ts
@@ -3,10 +3,15 @@ import {
   WorkerParentIO,
   type DestroyableIoInterface,
 } from "@kunkun/kkrpc";
-// import { Worker } from "node:worker_threads";
+import { Effect } from "effect";
 import { Worker as NodeWorker } from "node:worker_threads";
 import type { WorkerOptions } from "node:worker_threads";
-import type { HealthCheckResult, IService, ServiceStatus } from "./interface";
+import type {
+  HealthCheckResult,
+  IService,
+  IServiceRPC,
+  ServiceStatus,
+} from "./interface";
 import { BaseService } from "./BaseService";
 
 export interface WorkerServiceOptions {
@@ -19,9 +24,9 @@ export interface WorkerServiceOptions {
 export class WorkerService extends BaseService {
   private worker: NodeWorker | null = null;
   private io: DestroyableIoInterface | null = null;
-  private rpc: RPCChannel<object, IService, DestroyableIoInterface> | null =
+  private rpc: RPCChannel<object, IServiceRPC, DestroyableIoInterface> | null =
     null;
-  private api: IService | null = null;
+  private api: IServiceRPC | null = null;
   private options: WorkerServiceOptions;
   private autoTerminating = false;
   private terminateTimeout: NodeJS.Timeout | null = null;
@@ -33,11 +38,9 @@ export class WorkerService extends BaseService {
   }
 
   private initWorker(): void {
-    // Clean up any existing worker to ensure a fresh start
     this.cleanup();
 
     try {
-      // Merge default worker options with custom options and add workerData
       const workerOptions: WorkerOptions = {
         ...(this.options.workerOptions || {}),
         ...(this.options.workerData !== undefined
@@ -47,34 +50,23 @@ export class WorkerService extends BaseService {
 
       this.worker = new NodeWorker(this.options.workerURL.toString(), workerOptions);
       this.io = new WorkerParentIO(this.worker as any);
-      this.rpc = new RPCChannel<object, IService, DestroyableIoInterface>(
+      this.rpc = new RPCChannel<object, IServiceRPC, DestroyableIoInterface>(
         this.io,
         {}
       );
       this.api = this.rpc.getAPI();
 
-      // Monitor worker termination
       this.worker.addListener("error", (event) => {
         console.error(`Worker error event for ${this.name}:`, event);
         this.workerStatus = "crashed";
         this.cleanup();
       });
-      // this.worker.addEventListener("error", (event) => {
-      //   console.error(`Worker error event for ${this.name}:`, event);
-      //   this.workerStatus = "crashed";
-      //   this.cleanup();
-      // });
 
-      // this.worker.addEventListener("messageerror", (event) => {
-      //   console.error(`Worker message error for ${this.name}:`, event);
-      //   this.workerStatus = "unhealthy";
-      // });
       this.worker.addListener("messageerror", (event) => {
         console.error(`Worker message error for ${this.name}:`, event);
         this.workerStatus = "unhealthy";
       });
 
-      // Handle clean worker exit
       if (this.options.autoTerminate) {
         this.autoTerminating = true;
       }
@@ -117,9 +109,8 @@ export class WorkerService extends BaseService {
     this.api = null;
   }
 
-  public async start(): Promise<void> {
-    try {
-      // Set status to running right away
+  protected onStart(): Effect.Effect<void, unknown> {
+    return Effect.tryPromise(async () => {
       this.workerStatus = "running";
       this.initWorker();
 
@@ -127,67 +118,71 @@ export class WorkerService extends BaseService {
         throw new Error(`Failed to initialize worker for ${this.name}`);
       }
 
-      // Make sure API is ready by calling a method
       await this.api.start();
 
       if (this.options.autoTerminate && this.io) {
-        // For jobs that are meant to run and exit
         this.workerStatus = "stopping";
         this.cleanup();
         this.workerStatus = "stopped";
       }
-    } catch (error) {
-      console.error(`Error starting worker service ${this.name}:`, error);
-      this.workerStatus = "crashed";
-      this.cleanup();
-      throw error;
-    }
+    }).pipe(
+      Effect.tapError((error) =>
+        Effect.sync(() => {
+          console.error(`Error starting worker service ${this.name}:`, error);
+          this.workerStatus = "crashed";
+          this.cleanup();
+        })
+      )
+    );
   }
 
-  public async stop(): Promise<void> {
-    if (this.workerStatus === "stopped" || !this.api) {
-      return;
-    }
+  protected onStop(): Effect.Effect<void, unknown> {
+    return Effect.tryPromise(async () => {
+      if (this.workerStatus === "stopped" || !this.api) {
+        return;
+      }
 
-    try {
       this.workerStatus = "stopping";
 
       try {
-        // Attempt to stop gracefully
         await this.api.stop();
       } catch (error) {
         console.error(`Error during API stop for ${this.name}:`, error);
-        // Continue with cleanup even if stop call fails
       }
 
       this.cleanup();
       this.workerStatus = "stopped";
-    } catch (error) {
-      console.error(`Error stopping worker service ${this.name}:`, error);
-      this.workerStatus = "crashed";
-      this.cleanup();
-      throw error;
-    }
+    }).pipe(
+      Effect.tapError((error) =>
+        Effect.sync(() => {
+          console.error(`Error stopping worker service ${this.name}:`, error);
+          this.workerStatus = "crashed";
+          this.cleanup();
+        })
+      )
+    );
   }
 
-  public override async healthCheck(): Promise<HealthCheckResult> {
+  public override healthCheck(): Effect.Effect<HealthCheckResult, unknown> {
     if (this.workerStatus === "running" && this.api) {
-      try {
-        // Try to get health check from the worker service itself
-        return await this.api.healthCheck();
-      } catch (error) {
-        console.error(`Health check failed for ${this.name}:`, error);
-        return {
-          status: "unhealthy",
-          details: { error: String(error) },
-        };
-      }
+      return Effect.tryPromise(() => this.api!.healthCheck()).pipe(
+        Effect.tapError((error) =>
+          Effect.sync(() => {
+            console.error(`Health check failed for ${this.name}:`, error);
+          })
+        ),
+        Effect.catchAll((error) =>
+          Effect.succeed({
+            status: "unhealthy",
+            details: { error: String(error) },
+          } as HealthCheckResult)
+        )
+      );
     }
 
-    // Return our tracked status if we can't reach the worker
-    return {
+    return Effect.succeed({
       status: this.workerStatus,
       details: { isWorker: true },
-    };
+    });
   }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { Effect } from "effect";
 import type { IServiceManager, HealthCheckResult } from "./interface";
 import { describeRoute, openAPISpecs } from "hono-openapi";
 import * as v from "valibot";
@@ -213,8 +214,9 @@ export function createServiceManagerAPI(
         return c.json({ error: `Service '${name}' not found` }, 404);
       }
 
-      const health: HealthCheckResult =
-        await serviceManager.healthCheckService(name);
+      const health: HealthCheckResult = await Effect.runPromise(
+        serviceManager.healthCheckService(name)
+      );
 
       return c.json({
         name: service.name,
@@ -248,7 +250,7 @@ export function createServiceManagerAPI(
     async (c) => {
       const { name } = c.req.valid("param");
       try {
-        await serviceManager.startService(name);
+        await Effect.runPromise(serviceManager.startService(name));
         return c.json({ message: `Service '${name}' started` });
       } catch (error) {
         return c.json(
@@ -283,7 +285,7 @@ export function createServiceManagerAPI(
     async (c) => {
       const { name } = c.req.valid("param");
       try {
-        await serviceManager.stopService(name);
+        await Effect.runPromise(serviceManager.stopService(name));
         return c.json({ message: `Service '${name}' stopped` });
       } catch (error) {
         return c.json(
@@ -318,7 +320,7 @@ export function createServiceManagerAPI(
     async (c) => {
       const { name } = c.req.valid("param");
       try {
-        await serviceManager.restartService(name);
+        await Effect.runPromise(serviceManager.restartService(name));
         return c.json({ message: `Service '${name}' restarted` });
       } catch (error) {
         return c.json(
@@ -388,7 +390,9 @@ export function createServiceManagerAPI(
     async (c) => {
       const { name } = c.req.valid("param");
       try {
-        const health = await serviceManager.healthCheckService(name);
+        const health = await Effect.runPromise(
+          serviceManager.healthCheckService(name)
+        );
         return c.json(health);
       } catch (error) {
         return c.json(
@@ -423,7 +427,9 @@ export function createServiceManagerAPI(
     }),
     async (c) => {
       try {
-        const health = await serviceManager.healthCheckAllServices();
+        const health = await Effect.runPromise(
+          serviceManager.healthCheckAllServices()
+        );
         return c.json(health);
       } catch (error) {
         return c.json(
@@ -456,7 +462,7 @@ export function createServiceManagerAPI(
     }),
     async (c) => {
       try {
-        await serviceManager.startAllServices();
+        await Effect.runPromise(serviceManager.startAllServices());
         return c.json({ message: "All services started" });
       } catch (error) {
         return c.json({ error: `Failed to start all services: ${error}` }, 500);
@@ -486,7 +492,7 @@ export function createServiceManagerAPI(
     }),
     async (c) => {
       try {
-        await serviceManager.stopAllServices();
+        await Effect.runPromise(serviceManager.stopAllServices());
         return c.json({ message: "All services stopped" });
       } catch (error) {
         return c.json({ error: `Failed to stop all services: ${error}` }, 500);

--- a/src/createService.ts
+++ b/src/createService.ts
@@ -1,0 +1,24 @@
+import { Effect } from "effect";
+import type { HealthCheckResult, IService } from "./interface";
+
+export interface ServiceDefinition {
+  name: string;
+  start: () => Effect.Effect<void, unknown>;
+  stop?: () => Effect.Effect<void, unknown>;
+  healthCheck?: () => Effect.Effect<HealthCheckResult, unknown>;
+}
+
+export function createService(definition: ServiceDefinition): IService {
+  return {
+    name: definition.name,
+    start: definition.start,
+    stop: definition.stop ?? (() => Effect.void),
+    healthCheck:
+      definition.healthCheck ??
+      (() =>
+        Effect.succeed({
+          status: "stopped",
+          details: {},
+        })),
+  };
+}

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,3 +1,5 @@
+import { Effect } from "effect";
+
 export type ServiceStatus =
   | "stopped"
   | "running"
@@ -9,11 +11,17 @@ export type RestartPolicy = "always" | "unless-stopped" | "on-failure" | "no";
 
 export interface HealthCheckResult {
   status: ServiceStatus;
-  details?: Record<string, any>;
+  details?: Record<string, unknown>;
 }
 
 export interface IService {
   name: string;
+  start(): Effect.Effect<void, unknown>;
+  stop(): Effect.Effect<void, unknown>;
+  healthCheck(): Effect.Effect<HealthCheckResult, unknown>;
+}
+
+export interface IServiceRPC {
   start(): Promise<void>;
   stop(): Promise<void>;
   healthCheck(): Promise<HealthCheckResult>;
@@ -31,14 +39,19 @@ export interface ServiceConfig {
 }
 
 export interface IServiceManager {
-  services: IService[];
+  readonly services: IService[];
   addService(service: IService, config?: ServiceConfig): void;
   removeService(serviceName: string): void;
-  startService(serviceName: string): Promise<void>;
-  stopService(serviceName: string): Promise<void>;
-  restartService(serviceName: string): Promise<void>;
-  healthCheckService(serviceName: string): Promise<HealthCheckResult>;
-  startAllServices(): Promise<void>;
-  stopAllServices(): Promise<void>;
-  healthCheckAllServices(): Promise<Record<string, HealthCheckResult>>;
+  startService(serviceName: string): Effect.Effect<void, unknown>;
+  stopService(serviceName: string): Effect.Effect<void, unknown>;
+  restartService(serviceName: string): Effect.Effect<void, unknown>;
+  healthCheckService(
+    serviceName: string
+  ): Effect.Effect<HealthCheckResult, unknown>;
+  startAllServices(): Effect.Effect<void, unknown>;
+  stopAllServices(): Effect.Effect<void, unknown>;
+  healthCheckAllServices(): Effect.Effect<
+    Record<string, HealthCheckResult>,
+    unknown
+  >;
 }


### PR DESCRIPTION
## Summary
- finalize the Effect-based service manager with restart handling, RPC bridging, and new helper utilities
- migrate the UI and worker/example services to the Effect runtime and expose a functional createService helper
- refresh tests and docs to align with the new Effect-centric API

## Testing
- npm run check-types
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68cc42fce080832fa985f9e6be3b1b5f